### PR TITLE
Add config module for token management

### DIFF
--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearConfig,
+  getDnsToken,
+  getToken,
+  requireDnsToken,
+  requireToken,
+  setConfig,
+} from "./config.js";
+
+describe("config", () => {
+  beforeEach(() => {
+    vi.stubEnv("HETZNER_TOKEN", "");
+    vi.stubEnv("HETZNER_DNS_TOKEN", "");
+    clearConfig();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    clearConfig();
+  });
+
+  describe("getToken", () => {
+    it("returns CLI token when provided", () => {
+      expect(getToken("cli-token")).toBe("cli-token");
+    });
+
+    it("returns env token when no CLI token", () => {
+      vi.stubEnv("HETZNER_TOKEN", "env-token");
+      expect(getToken()).toBe("env-token");
+    });
+
+    it("returns config token when no CLI or env token", () => {
+      setConfig({ token: "config-token" });
+      expect(getToken()).toBe("config-token");
+    });
+
+    it("returns undefined when no token available", () => {
+      expect(getToken()).toBeUndefined();
+    });
+  });
+
+  describe("getDnsToken", () => {
+    it("returns CLI token when provided", () => {
+      expect(getDnsToken("cli-dns-token")).toBe("cli-dns-token");
+    });
+
+    it("returns env token when no CLI token", () => {
+      vi.stubEnv("HETZNER_DNS_TOKEN", "env-dns-token");
+      expect(getDnsToken()).toBe("env-dns-token");
+    });
+
+    it("returns config token when no CLI or env token", () => {
+      setConfig({ dnsToken: "config-dns-token" });
+      expect(getDnsToken()).toBe("config-dns-token");
+    });
+  });
+
+  describe("requireToken", () => {
+    it("returns token when available", () => {
+      setConfig({ token: "my-token" });
+      expect(requireToken()).toBe("my-token");
+    });
+
+    it("throws when no token available", () => {
+      expect(() => requireToken()).toThrow("No Hetzner API token found");
+    });
+  });
+
+  describe("requireDnsToken", () => {
+    it("returns token when available", () => {
+      setConfig({ dnsToken: "my-dns-token" });
+      expect(requireDnsToken()).toBe("my-dns-token");
+    });
+
+    it("throws when no token available", () => {
+      expect(() => requireDnsToken()).toThrow("No Hetzner DNS token found");
+    });
+  });
+
+  describe("setConfig", () => {
+    it("sets multiple config values", () => {
+      setConfig({ token: "test-token", defaultLocation: "fsn1" });
+      expect(getToken()).toBe("test-token");
+    });
+  });
+});

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,0 +1,92 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import Conf from "conf";
+
+export interface Config {
+  token?: string;
+  dnsToken?: string;
+  defaultLocation?: string;
+  defaultServerType?: string;
+  defaultImage?: string;
+}
+
+const schema = {
+  token: { type: "string" as const },
+  dnsToken: { type: "string" as const },
+  defaultLocation: { type: "string" as const },
+  defaultServerType: { type: "string" as const },
+  defaultImage: { type: "string" as const },
+};
+
+let store: Conf<Config> | null = null;
+
+function getStore(): Conf<Config> {
+  if (!store) {
+    store = new Conf<Config>({
+      projectName: "hetzner",
+      cwd: join(homedir(), ".config", "hetzner"),
+      schema,
+    });
+  }
+  return store;
+}
+
+export function getConfig(): Config {
+  return getStore().store;
+}
+
+export function setConfig(config: Partial<Config>): void {
+  const currentConfig = getConfig();
+  const newConfig = { ...currentConfig, ...config };
+  for (const [key, value] of Object.entries(newConfig)) {
+    if (value !== undefined) {
+      getStore().set(key, value);
+    }
+  }
+}
+
+export function clearConfig(): void {
+  getStore().clear();
+}
+
+export function getToken(cliToken?: string): string | undefined {
+  if (cliToken) {
+    return cliToken;
+  }
+  const envToken = process.env.HETZNER_TOKEN;
+  if (envToken) {
+    return envToken;
+  }
+  return getConfig().token;
+}
+
+export function getDnsToken(cliToken?: string): string | undefined {
+  if (cliToken) {
+    return cliToken;
+  }
+  const envToken = process.env.HETZNER_DNS_TOKEN;
+  if (envToken) {
+    return envToken;
+  }
+  return getConfig().dnsToken;
+}
+
+export function requireToken(cliToken?: string): string {
+  const token = getToken(cliToken);
+  if (!token) {
+    throw new Error(
+      "No Hetzner API token found. Set HETZNER_TOKEN environment variable or configure token in the TUI.",
+    );
+  }
+  return token;
+}
+
+export function requireDnsToken(cliToken?: string): string {
+  const token = getDnsToken(cliToken);
+  if (!token) {
+    throw new Error(
+      "No Hetzner DNS token found. Set HETZNER_DNS_TOKEN environment variable or configure token in the TUI.",
+    );
+  }
+  return token;
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,10 @@
+export {
+  clearConfig,
+  getConfig,
+  getDnsToken,
+  getToken,
+  requireDnsToken,
+  requireToken,
+  setConfig,
+  type Config,
+} from "./config.js";


### PR DESCRIPTION
## Summary

- Add config module with token management functions
- Support CLI token, environment variable, and config file fallbacks
- Share config file with hetzner-cli at `~/.config/hetzner/config.json`
- Add comprehensive tests for all config functions

## Functions

- `getToken()` / `getDnsToken()` - Get tokens with priority: CLI arg > env var > config
- `requireToken()` / `requireDnsToken()` - Get tokens or throw descriptive error
- `setConfig()` / `clearConfig()` - Manage config values

## Test Plan

- [x] 12 new tests covering all config functions
- [x] Tests verify token priority (CLI > env > config)
- [x] Tests verify error messages

Closes #3