### PR TITLE
Add base components (Header, Footer, CardBox, Spinner)

### DIFF
--- a/src/components/CardBox.test.tsx
+++ b/src/components/CardBox.test.tsx
@@ -1,0 +1,24 @@
+import { Text } from "ink";
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import CardBox from "./CardBox.js";
+
+describe("CardBox", () => {
+  it("renders children", () => {
+    const { lastFrame } = render(
+      <CardBox>
+        <Text>Content here</Text>
+      </CardBox>,
+    );
+    expect(lastFrame()).toContain("Content here");
+  });
+
+  it("renders title when provided", () => {
+    const { lastFrame } = render(
+      <CardBox title="My Card">
+        <Text>Content</Text>
+      </CardBox>,
+    );
+    expect(lastFrame()).toContain("My Card");
+  });
+});

--- a/src/components/CardBox.tsx
+++ b/src/components/CardBox.tsx
@@ -1,0 +1,31 @@
+import { Box, Text } from "ink";
+import type { ReactNode } from "react";
+import { colors } from "../ui/index.js";
+
+interface CardBoxProps {
+  title?: string;
+  children: ReactNode;
+  borderColor?: string;
+}
+
+export default function CardBox({
+  title,
+  children,
+  borderColor = colors.primary,
+}: CardBoxProps) {
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={borderColor}
+      paddingX={1}
+    >
+      {title && (
+        <Text bold color={colors.primary}>
+          {title}
+        </Text>
+      )}
+      {children}
+    </Box>
+  );
+}

--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -1,0 +1,22 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import Footer from "./Footer.js";
+
+describe("Footer", () => {
+  it("renders key bindings", () => {
+    const bindings = [
+      { key: "q", label: "Quit" },
+      { key: "r", label: "Refresh" },
+    ];
+    const { lastFrame } = render(<Footer bindings={bindings} />);
+    expect(lastFrame()).toContain("q");
+    expect(lastFrame()).toContain("Quit");
+    expect(lastFrame()).toContain("r");
+    expect(lastFrame()).toContain("Refresh");
+  });
+
+  it("renders status when provided", () => {
+    const { lastFrame } = render(<Footer status="Connected" />);
+    expect(lastFrame()).toContain("Connected");
+  });
+});

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,40 @@
+import { Box, Text } from "ink";
+import { colors } from "../ui/index.js";
+
+interface KeyBinding {
+  key: string;
+  label: string;
+}
+
+interface FooterProps {
+  bindings?: KeyBinding[];
+  status?: string;
+}
+
+export default function Footer({ bindings = [], status }: FooterProps) {
+  return (
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
+      marginTop={1}
+      paddingTop={1}
+      borderStyle="single"
+      borderTop
+      borderBottom={false}
+      borderLeft={false}
+      borderRight={false}
+    >
+      <Box gap={2}>
+        {bindings.map(({ key, label }) => (
+          <Box key={key}>
+            <Text color={colors.accent} bold>
+              {key}
+            </Text>
+            <Text color={colors.muted}> {label}</Text>
+          </Box>
+        ))}
+      </Box>
+      {status && <Text color={colors.muted}>{status}</Text>}
+    </Box>
+  );
+}

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import Header from "./Header.js";
+
+describe("Header", () => {
+  it("renders the title", () => {
+    const { lastFrame } = render(<Header title="Test Title" />);
+    expect(lastFrame()).toContain("Test Title");
+  });
+
+  it("renders the subtitle when provided", () => {
+    const { lastFrame } = render(
+      <Header title="Title" subtitle="Subtitle text" />,
+    );
+    expect(lastFrame()).toContain("Subtitle text");
+  });
+});

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,19 @@
+import { Box, Text } from "ink";
+import Gradient from "ink-gradient";
+import { colors } from "../ui/index.js";
+
+interface HeaderProps {
+  title: string;
+  subtitle?: string;
+}
+
+export default function Header({ title, subtitle }: HeaderProps) {
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Gradient name="rainbow">
+        <Text bold>{title}</Text>
+      </Gradient>
+      {subtitle && <Text color={colors.muted}>{subtitle}</Text>}
+    </Box>
+  );
+}

--- a/src/components/LoadingSpinner.test.tsx
+++ b/src/components/LoadingSpinner.test.tsx
@@ -1,0 +1,15 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import LoadingSpinner from "./LoadingSpinner.js";
+
+describe("LoadingSpinner", () => {
+  it("renders default loading message", () => {
+    const { lastFrame } = render(<LoadingSpinner />);
+    expect(lastFrame()).toContain("Loading...");
+  });
+
+  it("renders custom message", () => {
+    const { lastFrame } = render(<LoadingSpinner message="Fetching servers" />);
+    expect(lastFrame()).toContain("Fetching servers");
+  });
+});

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,0 +1,20 @@
+import { Box, Text } from "ink";
+import Spinner from "ink-spinner";
+import { colors } from "../ui/index.js";
+
+interface LoadingSpinnerProps {
+  message?: string;
+}
+
+export default function LoadingSpinner({
+  message = "Loading...",
+}: LoadingSpinnerProps) {
+  return (
+    <Box>
+      <Text color={colors.primary}>
+        <Spinner type="dots" />
+      </Text>
+      <Text> {message}</Text>
+    </Box>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,4 @@
+export { default as CardBox } from "./CardBox.js";
+export { default as Footer } from "./Footer.js";
+export { default as Header } from "./Header.js";
+export { default as LoadingSpinner } from "./LoadingSpinner.js";


### PR DESCRIPTION
## Summary

- Add Header component with gradient title using ink-gradient
- Add Footer component with key bindings display
- Add CardBox component for bordered content sections
- Add LoadingSpinner component with customizable message
- Add comprehensive tests for all components

## Components

| Component | Purpose |
|-----------|---------|
| `Header` | Title bar with gradient effect and optional subtitle |
| `Footer` | Key bindings display and status |
| `CardBox` | Bordered container for content |
| `LoadingSpinner` | Loading indicator with message |

## Test Plan

- [x] 8 new tests covering all components
- [x] All checks pass

Closes #7