### PR TITLE
Add WelcomeScreen and SetupWizard

### DIFF
--- a/src/screens/SetupWizard.test.tsx
+++ b/src/screens/SetupWizard.test.tsx
@@ -1,0 +1,27 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import SetupWizard from "./SetupWizard.js";
+
+describe("SetupWizard", () => {
+  it("renders setup wizard header", () => {
+    const { lastFrame } = render(
+      <SetupWizard onComplete={() => {}} onSkip={() => {}} />,
+    );
+    expect(lastFrame()).toContain("Setup Wizard");
+  });
+
+  it("shows cloud token step first", () => {
+    const { lastFrame } = render(
+      <SetupWizard onComplete={() => {}} onSkip={() => {}} />,
+    );
+    expect(lastFrame()).toContain("Step 1");
+    expect(lastFrame()).toContain("Cloud");
+  });
+
+  it("shows skip instruction", () => {
+    const { lastFrame } = render(
+      <SetupWizard onComplete={() => {}} onSkip={() => {}} />,
+    );
+    expect(lastFrame()).toContain("Escape");
+  });
+});

--- a/src/screens/SetupWizard.tsx
+++ b/src/screens/SetupWizard.tsx
@@ -1,0 +1,105 @@
+import { TextInput } from "@inkjs/ui";
+import { Box, Text, useInput } from "ink";
+import { useState } from "react";
+import { Header } from "../components/index.js";
+import { setConfig } from "../config/index.js";
+import { colors, symbols } from "../ui/index.js";
+
+type Step = "cloud" | "dns" | "complete";
+
+interface SetupWizardProps {
+  onComplete: () => void;
+  onSkip?: () => void;
+}
+
+export default function SetupWizard({ onComplete, onSkip }: SetupWizardProps) {
+  const [step, setStep] = useState<Step>("cloud");
+  const [cloudToken, setCloudToken] = useState("");
+
+  useInput((_input, key) => {
+    if (key.escape && onSkip) {
+      onSkip();
+    }
+  });
+
+  const handleCloudTokenSubmit = (value: string) => {
+    if (value.trim()) {
+      setCloudToken(value.trim());
+      setConfig({ token: value.trim() });
+    }
+    setStep("dns");
+  };
+
+  const handleDnsTokenSubmit = (value: string) => {
+    if (value.trim()) {
+      setConfig({ dnsToken: value.trim() });
+    }
+    setStep("complete");
+    onComplete();
+  };
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Header title="Setup Wizard" subtitle="Configure your Hetzner tokens" />
+
+      <Box flexDirection="column" marginTop={1}>
+        {step === "cloud" && (
+          <Box flexDirection="column">
+            <Text>
+              <Text color={colors.primary} bold>
+                Step 1:
+              </Text>{" "}
+              Hetzner Cloud API Token
+            </Text>
+            <Text color={colors.muted}>
+              Get your token from: https://console.hetzner.cloud/projects
+            </Text>
+            <Text color={colors.muted}>
+              {symbols.arrow} Select a project {symbols.arrow} Security{" "}
+              {symbols.arrow} API Tokens
+            </Text>
+            <Box marginTop={1}>
+              <Text>Token: </Text>
+              <TextInput
+                placeholder="Enter token (or press Enter to skip)"
+                onSubmit={handleCloudTokenSubmit}
+              />
+            </Box>
+          </Box>
+        )}
+
+        {step === "dns" && (
+          <Box flexDirection="column">
+            <Text color={colors.success}>
+              {symbols.success} Cloud token {cloudToken ? "saved" : "skipped"}
+            </Text>
+            <Box marginTop={1} flexDirection="column">
+              <Text>
+                <Text color={colors.primary} bold>
+                  Step 2:
+                </Text>{" "}
+                Hetzner DNS API Token (optional)
+              </Text>
+              <Text color={colors.muted}>
+                Get your token from: https://dns.hetzner.com/settings/api-token
+              </Text>
+              <Box marginTop={1}>
+                <Text>Token: </Text>
+                <TextInput
+                  placeholder="Enter token (or press Enter to skip)"
+                  onSubmit={handleDnsTokenSubmit}
+                />
+              </Box>
+            </Box>
+          </Box>
+        )}
+      </Box>
+
+      <Box marginTop={2}>
+        <Text dimColor>
+          Press <Text color={colors.muted}>Escape</Text> to skip setup
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/screens/WelcomeScreen.test.tsx
+++ b/src/screens/WelcomeScreen.test.tsx
@@ -1,0 +1,15 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import WelcomeScreen from "./WelcomeScreen.js";
+
+describe("WelcomeScreen", () => {
+  it("renders welcome message", () => {
+    const { lastFrame } = render(<WelcomeScreen onContinue={() => {}} />);
+    expect(lastFrame()).toContain("Hetzner");
+  });
+
+  it("shows continue instruction", () => {
+    const { lastFrame } = render(<WelcomeScreen onContinue={() => {}} />);
+    expect(lastFrame()).toContain("continue");
+  });
+});

--- a/src/screens/WelcomeScreen.tsx
+++ b/src/screens/WelcomeScreen.tsx
@@ -1,0 +1,50 @@
+import { Box, Text, useInput } from "ink";
+import Gradient from "ink-gradient";
+import { colors } from "../ui/index.js";
+
+interface WelcomeScreenProps {
+  onContinue: () => void;
+}
+
+export default function WelcomeScreen({ onContinue }: WelcomeScreenProps) {
+  useInput((input, key) => {
+    if (key.return || input === " ") {
+      onContinue();
+    }
+  });
+
+  return (
+    <Box
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      padding={2}
+    >
+      <Box marginBottom={1}>
+        <Gradient name="rainbow">
+          <Text bold>
+            {`
+  _   _      _                        _____ _   _ ___
+ | | | | ___| |_ _____ __   ___ _ _  |_   _| | | |_ _|
+ | |_| |/ _ \\ __|_  / '_ \\ / _ \\ '_|   | | | | | || |
+ |  _  |  __/ |_ / /| | | |  __/ |     | | | |_| || |
+ |_| |_|\\___|\\__/___|_| |_|\\___|_|     |_|  \\___/|___|
+            `}
+          </Text>
+        </Gradient>
+      </Box>
+
+      <Text color={colors.muted}>
+        Interactive terminal UI for Hetzner Cloud and DNS
+      </Text>
+
+      <Box marginTop={2}>
+        <Text dimColor>Press </Text>
+        <Text color={colors.accent} bold>
+          Enter
+        </Text>
+        <Text dimColor> to continue</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -1,0 +1,2 @@
+export { default as SetupWizard } from "./SetupWizard.js";
+export { default as WelcomeScreen } from "./WelcomeScreen.js";


### PR DESCRIPTION
## Summary

- Add WelcomeScreen with ASCII art logo and gradient effect
- Add SetupWizard for first-time token configuration
- Support both Cloud and DNS token setup with step-by-step flow
- Allow skipping setup with Escape key
- Add tests for both screens

## Screens

| Screen | Purpose |
|--------|---------|
| `WelcomeScreen` | Initial landing with logo, press Enter to continue |
| `SetupWizard` | Two-step token configuration (Cloud token, DNS token) |

## Test Plan

- [x] 5 new tests covering screen rendering
- [x] All checks pass

Closes #9