### PR TITLE
Add ServersScreen for server management

### DIFF
--- a/src/screens/ServersScreen.test.tsx
+++ b/src/screens/ServersScreen.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import ServersScreen from "./ServersScreen.js";
+
+describe("ServersScreen", () => {
+  it("renders header with Servers title", () => {
+    const { lastFrame } = render(<ServersScreen onBack={() => {}} />);
+    expect(lastFrame()).toContain("Servers");
+  });
+
+  it("shows loading state initially", () => {
+    const { lastFrame } = render(<ServersScreen onBack={() => {}} />);
+    const frame = lastFrame() ?? "";
+    // Should show either Loading or the content
+    expect(frame.length).toBeGreaterThan(0);
+  });
+
+  it("shows back navigation hint", () => {
+    const { lastFrame } = render(<ServersScreen onBack={() => {}} />);
+    const frame = lastFrame() ?? "";
+    expect(frame.includes("Esc") || frame.includes("Back")).toBe(true);
+  });
+});

--- a/src/screens/ServersScreen.tsx
+++ b/src/screens/ServersScreen.tsx
@@ -1,0 +1,119 @@
+import { Hetzner, type Server as HetznerServer } from "@tomkp/hetzner";
+import { Box, Text, useInput } from "ink";
+import { useEffect, useState } from "react";
+import {
+  CardBox,
+  Footer,
+  Header,
+  LoadingSpinner,
+} from "../components/index.js";
+import { getToken } from "../config/index.js";
+import { colors, formatStatus, symbols } from "../ui/index.js";
+
+interface Server {
+  id: number;
+  name: string;
+  status: string;
+  publicIp: string;
+  serverType: string;
+  datacenter: string;
+}
+
+interface ServersScreenProps {
+  onBack: () => void;
+}
+
+export default function ServersScreen({ onBack }: ServersScreenProps) {
+  const [servers, setServers] = useState<Server[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      onBack();
+    }
+  });
+
+  useEffect(() => {
+    const fetchServers = async () => {
+      const token = getToken();
+      if (!token) {
+        setError("No API token configured. Please run setup first.");
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const client = new Hetzner(token);
+        const response = await client.servers.list();
+        const serverList = response.servers.map((s: HetznerServer) => ({
+          id: s.id,
+          name: s.name,
+          status: s.status,
+          publicIp: s.public_net?.ipv4?.ip ?? "No IP",
+          serverType: s.server_type?.name ?? "Unknown",
+          datacenter: s.datacenter?.name ?? "Unknown",
+        }));
+        setServers(serverList);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to fetch servers",
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchServers();
+  }, []);
+
+  const footerBindings = [
+    { key: "Esc", label: "Back" },
+    { key: "r", label: "Refresh" },
+  ];
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Header title="Servers" subtitle="Manage your Hetzner Cloud servers" />
+
+      <Box flexDirection="column" marginY={1}>
+        {loading && <LoadingSpinner message="Fetching servers..." />}
+
+        {error && (
+          <Box>
+            <Text color={colors.error}>
+              {symbols.error} {error}
+            </Text>
+          </Box>
+        )}
+
+        {!loading && !error && servers.length === 0 && (
+          <Text color={colors.muted}>No servers found.</Text>
+        )}
+
+        {!loading &&
+          !error &&
+          servers.map((server) => {
+            const status = formatStatus(server.status);
+            return (
+              <CardBox key={server.id}>
+                <Box justifyContent="space-between">
+                  <Box gap={1}>
+                    <Text color={status.color}>{status.symbol}</Text>
+                    <Text bold>{server.name}</Text>
+                  </Box>
+                  <Text color={colors.muted}>{server.serverType}</Text>
+                </Box>
+                <Box gap={2}>
+                  <Text color={colors.muted}>IP: {server.publicIp}</Text>
+                  <Text color={colors.muted}>DC: {server.datacenter}</Text>
+                </Box>
+              </CardBox>
+            );
+          })}
+      </Box>
+
+      <Footer bindings={footerBindings} status={`${servers.length} servers`} />
+    </Box>
+  );
+}

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -2,5 +2,6 @@ export {
   default as MainMenuScreen,
   type MenuAction,
 } from "./MainMenuScreen.js";
+export { default as ServersScreen } from "./ServersScreen.js";
 export { default as SetupWizard } from "./SetupWizard.js";
 export { default as WelcomeScreen } from "./WelcomeScreen.js";


### PR DESCRIPTION
## Summary

- Add ServersScreen to display Hetzner Cloud servers
- Show server status, IP address, type, and datacenter
- Loading spinner while fetching from API
- Error handling for API failures
- Back navigation with Escape key
- Status indicators using theme colors

## Features

- Lists all servers with status indicators
- CardBox display for each server
- Footer with navigation hints
- Integrates with @tomkp/hetzner API client

## Test Plan

- [x] 3 new tests covering screen rendering
- [x] All checks pass

Closes #13