### PR TITLE
Add generic ResourceScreen component

### DIFF
--- a/src/components/ResourceScreen.test.tsx
+++ b/src/components/ResourceScreen.test.tsx
@@ -1,0 +1,66 @@
+import { Text } from "ink";
+import { render } from "ink-testing-library";
+import { describe, expect, it, vi } from "vitest";
+import ResourceScreen from "./ResourceScreen.js";
+
+describe("ResourceScreen", () => {
+  it("renders title", () => {
+    const { lastFrame } = render(
+      <ResourceScreen
+        title="Test Resources"
+        subtitle="Test subtitle"
+        onBack={() => {}}
+        fetchData={async () => []}
+        renderItem={() => <Text>Item</Text>}
+        getItemKey={(item) => String(item)}
+      />,
+    );
+    expect(lastFrame()).toContain("Test Resources");
+  });
+
+  it("shows loading state initially", () => {
+    const { lastFrame } = render(
+      <ResourceScreen
+        title="Resources"
+        onBack={() => {}}
+        fetchData={() => new Promise(() => {})} // Never resolves
+        renderItem={() => <Text>Item</Text>}
+        getItemKey={(item) => String(item)}
+      />,
+    );
+    expect(lastFrame()).toContain("Loading");
+  });
+
+  it("shows empty state when no items", async () => {
+    const { lastFrame } = render(
+      <ResourceScreen
+        title="Resources"
+        onBack={() => {}}
+        fetchData={async () => []}
+        renderItem={() => <Text>Item</Text>}
+        getItemKey={(item) => String(item)}
+        emptyMessage="No items found"
+      />,
+    );
+    // Wait for state update
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain("No items found");
+    });
+  });
+
+  it("renders items when data is loaded", async () => {
+    const items = [{ id: 1, name: "Item 1" }];
+    const { lastFrame } = render(
+      <ResourceScreen
+        title="Resources"
+        onBack={() => {}}
+        fetchData={async () => items}
+        renderItem={(item) => <Text>{item.name}</Text>}
+        getItemKey={(item) => String(item.id)}
+      />,
+    );
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain("Item 1");
+    });
+  });
+});

--- a/src/components/ResourceScreen.tsx
+++ b/src/components/ResourceScreen.tsx
@@ -1,0 +1,93 @@
+import { Box, Text, useInput } from "ink";
+import { type ReactNode, useEffect, useState } from "react";
+import { colors, symbols } from "../ui/index.js";
+import Footer from "./Footer.js";
+import Header from "./Header.js";
+import LoadingSpinner from "./LoadingSpinner.js";
+
+interface ResourceScreenProps<T> {
+  title: string;
+  subtitle?: string;
+  onBack: () => void;
+  fetchData: () => Promise<T[]>;
+  renderItem: (item: T) => ReactNode;
+  getItemKey: (item: T) => string;
+  emptyMessage?: string;
+  loadingMessage?: string;
+  footerBindings?: Array<{ key: string; label: string }>;
+}
+
+export default function ResourceScreen<T>({
+  title,
+  subtitle,
+  onBack,
+  fetchData,
+  renderItem,
+  getItemKey,
+  emptyMessage = "No items found.",
+  loadingMessage = "Loading...",
+  footerBindings = [],
+}: ResourceScreenProps<T>) {
+  const [items, setItems] = useState<T[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      onBack();
+    }
+  });
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchData();
+        setItems(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load data");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, [fetchData]);
+
+  const defaultBindings = [
+    { key: "Esc", label: "Back" },
+    { key: "r", label: "Refresh" },
+    ...footerBindings,
+  ];
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Header title={title} subtitle={subtitle} />
+
+      <Box flexDirection="column" marginY={1}>
+        {loading && <LoadingSpinner message={loadingMessage} />}
+
+        {error && (
+          <Box>
+            <Text color={colors.error}>
+              {symbols.error} {error}
+            </Text>
+          </Box>
+        )}
+
+        {!loading && !error && items.length === 0 && (
+          <Text color={colors.muted}>{emptyMessage}</Text>
+        )}
+
+        {!loading &&
+          !error &&
+          items.map((item) => (
+            <Box key={getItemKey(item)} marginBottom={1}>
+              {renderItem(item)}
+            </Box>
+          ))}
+      </Box>
+
+      <Footer bindings={defaultBindings} status={`${items.length} items`} />
+    </Box>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,3 +2,4 @@ export { default as CardBox } from "./CardBox.js";
 export { default as Footer } from "./Footer.js";
 export { default as Header } from "./Header.js";
 export { default as LoadingSpinner } from "./LoadingSpinner.js";
+export { default as ResourceScreen } from "./ResourceScreen.js";


### PR DESCRIPTION
## Summary

- Create reusable ResourceScreen component for all resource types
- Handles loading, error, and empty states
- Configurable via props for title, fetch function, and item renderer
- Reduces code duplication across resource screens

## Props

| Prop | Type | Description |
|------|------|-------------|
| `title` | string | Screen header title |
| `subtitle` | string | Optional subtitle |
| `onBack` | function | Back navigation handler |
| `fetchData` | async function | Returns array of items |
| `renderItem` | function | Renders each item |
| `getItemKey` | function | Returns unique key for item |
| `emptyMessage` | string | Message when no items |
| `loadingMessage` | string | Loading state message |
| `footerBindings` | array | Additional footer key bindings |

## Test Plan

- [x] 4 new tests covering component states
- [x] All checks pass

Closes #15