### PR TITLE
Add PrimaryIPsScreen

### DIFF
--- a/src/screens/PrimaryIPsScreen.test.tsx
+++ b/src/screens/PrimaryIPsScreen.test.tsx
@@ -1,0 +1,16 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import PrimaryIPsScreen from "./PrimaryIPsScreen.js";
+
+describe("PrimaryIPsScreen", () => {
+  it("renders header with Primary IPs title", () => {
+    const { lastFrame } = render(<PrimaryIPsScreen onBack={() => {}} />);
+    expect(lastFrame()).toContain("Primary IPs");
+  });
+
+  it("shows back navigation hint", () => {
+    const { lastFrame } = render(<PrimaryIPsScreen onBack={() => {}} />);
+    const frame = lastFrame() ?? "";
+    expect(frame.includes("Esc") || frame.includes("Back")).toBe(true);
+  });
+});

--- a/src/screens/PrimaryIPsScreen.tsx
+++ b/src/screens/PrimaryIPsScreen.tsx
@@ -1,0 +1,60 @@
+import { Hetzner, type PrimaryIP } from "@tomkp/hetzner";
+import { Box, Text } from "ink";
+import { useCallback } from "react";
+import { CardBox, ResourceScreen } from "../components/index.js";
+import { getToken } from "../config/index.js";
+import { colors, symbols } from "../ui/index.js";
+
+interface PrimaryIPsScreenProps {
+  onBack: () => void;
+}
+
+export default function PrimaryIPsScreen({ onBack }: PrimaryIPsScreenProps) {
+  const fetchPrimaryIPs = useCallback(async () => {
+    const token = getToken();
+    if (!token) {
+      throw new Error("No API token configured. Please run setup first.");
+    }
+    const client = new Hetzner(token);
+    const response = await client.primaryIPs.list();
+    return response.primary_ips;
+  }, []);
+
+  const renderPrimaryIP = (ip: PrimaryIP) => {
+    const isAssigned = ip.assignee_id !== null;
+    return (
+      <CardBox>
+        <Box justifyContent="space-between">
+          <Box gap={1}>
+            <Text color={isAssigned ? colors.success : colors.muted}>
+              {isAssigned ? symbols.running : symbols.stopped}
+            </Text>
+            <Text bold>{ip.ip}</Text>
+          </Box>
+          <Text color={colors.muted}>{ip.type}</Text>
+        </Box>
+        <Box gap={2}>
+          <Text color={colors.muted}>
+            Assigned: {isAssigned ? `Server #${ip.assignee_id}` : "No"}
+          </Text>
+          <Text color={colors.muted}>
+            Datacenter: {ip.datacenter?.name ?? "Unknown"}
+          </Text>
+        </Box>
+      </CardBox>
+    );
+  };
+
+  return (
+    <ResourceScreen
+      title="Primary IPs"
+      subtitle="Manage your Hetzner Cloud primary IPs"
+      onBack={onBack}
+      fetchData={fetchPrimaryIPs}
+      renderItem={renderPrimaryIP}
+      getItemKey={(ip) => String(ip.id)}
+      emptyMessage="No primary IPs found."
+      loadingMessage="Fetching primary IPs..."
+    />
+  );
+}

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -7,6 +7,7 @@ export { default as FirewallsScreen } from "./FirewallsScreen.js";
 export { default as FloatingIPsScreen } from "./FloatingIPsScreen.js";
 export { default as LoadBalancersScreen } from "./LoadBalancersScreen.js";
 export { default as NetworksScreen } from "./NetworksScreen.js";
+export { default as PrimaryIPsScreen } from "./PrimaryIPsScreen.js";
 export { default as ServersScreen } from "./ServersScreen.js";
 export { default as SetupWizard } from "./SetupWizard.js";
 export { default as VolumesScreen } from "./VolumesScreen.js";


### PR DESCRIPTION
## Summary
- Adds PrimaryIPsScreen for managing Hetzner Cloud primary IPs
- Displays IP address, type, assignment status, and datacenter
- Uses ResourceScreen component for consistent UX

## Test plan
- [x] Tests for header rendering
- [x] Tests for back navigation hint
- [x] All lint, typecheck, and tests pass

Closes #29