### PR TITLE
Add PlacementGroupsScreen

### DIFF
--- a/src/screens/PlacementGroupsScreen.test.tsx
+++ b/src/screens/PlacementGroupsScreen.test.tsx
@@ -1,0 +1,16 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import PlacementGroupsScreen from "./PlacementGroupsScreen.js";
+
+describe("PlacementGroupsScreen", () => {
+  it("renders header with Placement Groups title", () => {
+    const { lastFrame } = render(<PlacementGroupsScreen onBack={() => {}} />);
+    expect(lastFrame()).toContain("Placement Groups");
+  });
+
+  it("shows back navigation hint", () => {
+    const { lastFrame } = render(<PlacementGroupsScreen onBack={() => {}} />);
+    const frame = lastFrame() ?? "";
+    expect(frame.includes("Esc") || frame.includes("Back")).toBe(true);
+  });
+});

--- a/src/screens/PlacementGroupsScreen.tsx
+++ b/src/screens/PlacementGroupsScreen.tsx
@@ -1,0 +1,57 @@
+import { Hetzner, type PlacementGroup } from "@tomkp/hetzner";
+import { Box, Text } from "ink";
+import { useCallback } from "react";
+import { CardBox, ResourceScreen } from "../components/index.js";
+import { getToken } from "../config/index.js";
+import { colors, formatDate } from "../ui/index.js";
+
+interface PlacementGroupsScreenProps {
+  onBack: () => void;
+}
+
+export default function PlacementGroupsScreen({
+  onBack,
+}: PlacementGroupsScreenProps) {
+  const fetchPlacementGroups = useCallback(async () => {
+    const token = getToken();
+    if (!token) {
+      throw new Error("No API token configured. Please run setup first.");
+    }
+    const client = new Hetzner(token);
+    const response = await client.placementGroups.list();
+    return response.placement_groups;
+  }, []);
+
+  const renderPlacementGroup = (group: PlacementGroup) => {
+    const serverCount = group.servers?.length ?? 0;
+    return (
+      <CardBox>
+        <Box justifyContent="space-between">
+          <Text bold>{group.name}</Text>
+          <Text color={colors.muted}>{group.type}</Text>
+        </Box>
+        <Box gap={2}>
+          <Text color={colors.muted}>Servers: {serverCount}</Text>
+          {group.created && (
+            <Text color={colors.muted}>
+              Created: {formatDate(group.created)}
+            </Text>
+          )}
+        </Box>
+      </CardBox>
+    );
+  };
+
+  return (
+    <ResourceScreen
+      title="Placement Groups"
+      subtitle="Manage your Hetzner Cloud placement groups"
+      onBack={onBack}
+      fetchData={fetchPlacementGroups}
+      renderItem={renderPlacementGroup}
+      getItemKey={(g) => String(g.id)}
+      emptyMessage="No placement groups found."
+      loadingMessage="Fetching placement groups..."
+    />
+  );
+}

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -7,6 +7,7 @@ export { default as FirewallsScreen } from "./FirewallsScreen.js";
 export { default as FloatingIPsScreen } from "./FloatingIPsScreen.js";
 export { default as LoadBalancersScreen } from "./LoadBalancersScreen.js";
 export { default as NetworksScreen } from "./NetworksScreen.js";
+export { default as PlacementGroupsScreen } from "./PlacementGroupsScreen.js";
 export { default as PrimaryIPsScreen } from "./PrimaryIPsScreen.js";
 export { default as ServersScreen } from "./ServersScreen.js";
 export { default as SetupWizard } from "./SetupWizard.js";


### PR DESCRIPTION
## Summary
- Adds PlacementGroupsScreen for managing Hetzner Cloud placement groups
- Displays group name, type, server count, and creation date
- Uses ResourceScreen component for consistent UX

## Test plan
- [x] Tests for header rendering
- [x] Tests for back navigation hint
- [x] All lint, typecheck, and tests pass

Closes #31