### PR TITLE
Add DNSZonesScreen

### DIFF
--- a/src/screens/DNSZonesScreen.test.tsx
+++ b/src/screens/DNSZonesScreen.test.tsx
@@ -1,0 +1,16 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import DNSZonesScreen from "./DNSZonesScreen.js";
+
+describe("DNSZonesScreen", () => {
+  it("renders header with DNS Zones title", () => {
+    const { lastFrame } = render(<DNSZonesScreen onBack={() => {}} />);
+    expect(lastFrame()).toContain("DNS Zones");
+  });
+
+  it("shows back navigation hint", () => {
+    const { lastFrame } = render(<DNSZonesScreen onBack={() => {}} />);
+    const frame = lastFrame() ?? "";
+    expect(frame.includes("Esc") || frame.includes("Back")).toBe(true);
+  });
+});

--- a/src/screens/DNSZonesScreen.tsx
+++ b/src/screens/DNSZonesScreen.tsx
@@ -1,0 +1,57 @@
+import { HetznerDns, type Zone } from "@tomkp/hetzner";
+import { Box, Text } from "ink";
+import { useCallback } from "react";
+import { CardBox, ResourceScreen } from "../components/index.js";
+import { getDnsToken } from "../config/index.js";
+import { colors, formatDate } from "../ui/index.js";
+
+interface DNSZonesScreenProps {
+  onBack: () => void;
+}
+
+export default function DNSZonesScreen({ onBack }: DNSZonesScreenProps) {
+  const fetchZones = useCallback(async () => {
+    const token = getDnsToken();
+    if (!token) {
+      throw new Error(
+        "No DNS API token configured. Please run setup first or set HETZNER_DNS_TOKEN.",
+      );
+    }
+    const client = new HetznerDns(token);
+    const response = await client.zones.list();
+    return response.zones;
+  }, []);
+
+  const renderZone = (zone: Zone) => {
+    const recordCount = zone.records_count ?? 0;
+    return (
+      <CardBox>
+        <Box justifyContent="space-between">
+          <Text bold>{zone.name}</Text>
+          <Text color={colors.muted}>TTL: {zone.ttl ?? "default"}</Text>
+        </Box>
+        <Box gap={2}>
+          <Text color={colors.muted}>Records: {recordCount}</Text>
+          {zone.created && (
+            <Text color={colors.muted}>
+              Created: {formatDate(zone.created)}
+            </Text>
+          )}
+        </Box>
+      </CardBox>
+    );
+  };
+
+  return (
+    <ResourceScreen
+      title="DNS Zones"
+      subtitle="Manage your Hetzner DNS zones"
+      onBack={onBack}
+      fetchData={fetchZones}
+      renderItem={renderZone}
+      getItemKey={(z) => z.id}
+      emptyMessage="No DNS zones found."
+      loadingMessage="Fetching DNS zones..."
+    />
+  );
+}

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -3,6 +3,7 @@ export {
   type MenuAction,
 } from "./MainMenuScreen.js";
 export { default as CertificatesScreen } from "./CertificatesScreen.js";
+export { default as DNSZonesScreen } from "./DNSZonesScreen.js";
 export { default as FirewallsScreen } from "./FirewallsScreen.js";
 export { default as FloatingIPsScreen } from "./FloatingIPsScreen.js";
 export { default as LoadBalancersScreen } from "./LoadBalancersScreen.js";


### PR DESCRIPTION
## Summary
- Adds DNSZonesScreen for managing Hetzner DNS zones
- Displays zone name, TTL, record count, and creation date
- Uses HetznerDns client with separate DNS API token
- Uses ResourceScreen component for consistent UX

## Test plan
- [x] Tests for header rendering
- [x] Tests for back navigation hint
- [x] All lint, typecheck, and tests pass

Closes #35