### PR TITLE
Add DNSRecordsScreen

### DIFF
--- a/src/screens/DNSRecordsScreen.test.tsx
+++ b/src/screens/DNSRecordsScreen.test.tsx
@@ -1,0 +1,16 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import DNSRecordsScreen from "./DNSRecordsScreen.js";
+
+describe("DNSRecordsScreen", () => {
+  it("renders header with DNS Records title", () => {
+    const { lastFrame } = render(<DNSRecordsScreen onBack={() => {}} />);
+    expect(lastFrame()).toContain("DNS Records");
+  });
+
+  it("shows back navigation hint", () => {
+    const { lastFrame } = render(<DNSRecordsScreen onBack={() => {}} />);
+    const frame = lastFrame() ?? "";
+    expect(frame.includes("Esc") || frame.includes("Back")).toBe(true);
+  });
+});

--- a/src/screens/DNSRecordsScreen.tsx
+++ b/src/screens/DNSRecordsScreen.tsx
@@ -1,0 +1,85 @@
+import { type Record as DnsRecord, HetznerDns } from "@tomkp/hetzner";
+import { Box, Text } from "ink";
+import { useCallback } from "react";
+import { CardBox, ResourceScreen } from "../components/index.js";
+import { getDnsToken } from "../config/index.js";
+import { colors } from "../ui/index.js";
+
+interface DNSRecordsScreenProps {
+  onBack: () => void;
+}
+
+interface RecordWithZone extends DnsRecord {
+  zoneName?: string;
+}
+
+export default function DNSRecordsScreen({ onBack }: DNSRecordsScreenProps) {
+  const fetchRecords = useCallback(async () => {
+    const token = getDnsToken();
+    if (!token) {
+      throw new Error(
+        "No DNS API token configured. Please run setup first or set HETZNER_DNS_TOKEN.",
+      );
+    }
+    const client = new HetznerDns(token);
+
+    // Fetch all zones first
+    const { zones } = await client.zones.list();
+
+    // Then fetch records for each zone
+    const allRecords: RecordWithZone[] = [];
+    for (const zone of zones) {
+      const { records } = await client.records.list({ zone_id: zone.id });
+      for (const record of records) {
+        allRecords.push({ ...record, zoneName: zone.name });
+      }
+    }
+
+    return allRecords;
+  }, []);
+
+  const renderRecord = (record: RecordWithZone) => {
+    const typeColor =
+      record.type === "A" || record.type === "AAAA"
+        ? colors.success
+        : record.type === "MX"
+          ? colors.warning
+          : colors.muted;
+
+    return (
+      <CardBox>
+        <Box justifyContent="space-between">
+          <Box gap={1}>
+            <Text color={typeColor} bold>
+              {record.type}
+            </Text>
+            <Text bold>{record.name || "@"}</Text>
+          </Box>
+          <Text color={colors.muted}>{record.zoneName}</Text>
+        </Box>
+        <Box gap={2}>
+          <Text color={colors.muted}>
+            Value:{" "}
+            {record.value.length > 40
+              ? `${record.value.slice(0, 40)}...`
+              : record.value}
+          </Text>
+          {record.ttl && <Text color={colors.muted}>TTL: {record.ttl}</Text>}
+        </Box>
+      </CardBox>
+    );
+  };
+
+  return (
+    <ResourceScreen
+      title="DNS Records"
+      subtitle="Manage your Hetzner DNS records"
+      onBack={onBack}
+      fetchData={fetchRecords}
+      renderItem={renderRecord}
+      getItemKey={(r) => r.id}
+      emptyMessage="No DNS records found."
+      loadingMessage="Fetching DNS records..."
+    />
+  );
+}

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -3,6 +3,7 @@ export {
   type MenuAction,
 } from "./MainMenuScreen.js";
 export { default as CertificatesScreen } from "./CertificatesScreen.js";
+export { default as DNSRecordsScreen } from "./DNSRecordsScreen.js";
 export { default as DNSZonesScreen } from "./DNSZonesScreen.js";
 export { default as FirewallsScreen } from "./FirewallsScreen.js";
 export { default as FloatingIPsScreen } from "./FloatingIPsScreen.js";


### PR DESCRIPTION
## Summary
- Adds DNSRecordsScreen for managing Hetzner DNS records
- Displays record type, name, value, TTL, and parent zone
- Fetches records from all zones and displays them together
- Uses HetznerDns client with DNS API token
- Uses ResourceScreen component for consistent UX

## Test plan
- [x] Tests for header rendering
- [x] Tests for back navigation hint
- [x] All lint, typecheck, and tests pass

Closes #37